### PR TITLE
Update to account for renames in suitcase, intake-bluesky.

### DIFF
--- a/Facility-Scale Deployment - Message Bus, MongoDB, intake server.ipynb
+++ b/Facility-Scale Deployment - Message Bus, MongoDB, intake server.ipynb
@@ -107,7 +107,7 @@
    "outputs": [],
    "source": [
     "from intake import Catalog\n",
-    "import intake_bluesky.mongo_layout1\n",
+    "import intake_bluesky.mongo_normalized\n",
     "\n",
     "catalog = Catalog('intake://localhost:5000')"
    ]

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,13 +1,13 @@
 event-model >=1.8.0rc3
 bluesky
 caproto
-intake-bluesky >=0.1.0a2
+intake-bluesky >=0.1.0a3
 ipympl
 matplotlib
 mongobox
 mongoquery
 ophyd
 suitcase-jsonl >=0.1.0b2
-suitcase-mongo >=0.1.0b4
+suitcase-mongo >=0.1.0b5
 suitcase-tiff
 tornado <5

--- a/catalog.yml
+++ b/catalog.yml
@@ -4,7 +4,7 @@ plugins:
 sources:
   xyz:                                                                          
     description: Some imaginary beamline
-    driver: intake_bluesky.mongo_layout1.BlueskyMongoCatalog
+    driver: intake_bluesky.mongo_normalized.BlueskyMongoCatalog
     container: catalog
     args:
       metadatastore_db: mongodb://localhost:27017/mds

--- a/consumer.py
+++ b/consumer.py
@@ -1,6 +1,6 @@
 from pymongo import MongoClient
 from bluesky.callbacks.zmq import RemoteDispatcher
-from suitcase.mongo_layout1 import Serializer
+from suitcase.mongo_normalized import Serializer
 
 # This listens to a lightweight (0MQ-based) message bus for Documents
 # and inserts them into MongoDB.


### PR DESCRIPTION
The ``mongo_layout1`` serialization is now called ``mogno_normalized``.

I have verified that I caught all instances of ``layout1`` by running
``git grep layout1``.